### PR TITLE
Added functions to `local.py` for loading scene graph data

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ id: 133089, image: 1159910, question: Why is the man cosplaying?, answer: For an
 ```python
 > import src.local as vg
 > 
-> # Convert full .json files to image-specific .jsons, save these to 'data/by-id'
+> # Convert full .json files to image-specific .jsons, save these to 'data/by-id'.
+> # These files will take up a total ~1.1G space on disk.
 > vg.SaveSceneGraphsById(dataDir='data/', imageDataDir='data/by-id/')
 > 
 > # Load scene graphs in 'data/by-id', from index 0 to 200.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,28 @@ id: 133089, image: 1159910, question: Why is the man cosplaying?, answer: For an
 > ./src/data/getQuestionAnswers.sh
 ```
 
+
+#### Get Scene Graphs for 200 images from local .json files
+
+```python
+> import src.local as vg
+> 
+> # Convert full .json files to image-specific .jsons, save these to 'data/by-id'.
+> # These files will take up a total ~1.1G space on disk.
+> vg.SaveSceneGraphsById(dataDir='data/', imageDataDir='data/by-id/')
+> 
+> # Load scene graphs in 'data/by-id', from index 0 to 200.
+> # We'll only keep scene graphs with at least 1 relationship.
+> scene_graphs = vg.GetSceneGraphs(startIndex=0, endIndex=-1, minRels=1,
+>                                  dataDir='data/', imageDataDir='data/by-id/')
+> 
+> print len(scene_graphs)
+149
+> 
+> print scene_graphs[0].objects
+[clock, street, shade, man, sneakers, headlight, car, bike, bike, sign, building, ... , street, sidewalk, trees, car, work truck]
+```
+
 ### License
 MIT License copyright Ranjay Krishna
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,27 @@ id: 133089, image: 1159910, question: Why is the man cosplaying?, answer: For an
 > ./src/data/getQuestionAnswers.sh
 ```
 
+
+#### Get Scene Graphs for 200 images from local .json files
+
+```python
+> import src.local as vg
+> 
+> # Convert full .json files to image-specific .jsons, save these to 'data/by-id'
+> vg.SaveSceneGraphsById(dataDir='data/', imageDataDir='data/by-id/')
+> 
+> # Load scene graphs in 'data/by-id', from index 0 to 200.
+> # We'll only keep scene graphs with at least 1 relationship.
+> scene_graphs = vg.GetSceneGraphs(startIndex=0, endIndex=-1, minRels=1,
+>                                  dataDir='data/', imageDataDir='data/by-id/')
+> 
+> print len(scene_graphs)
+149
+> 
+> print scene_graphs[0].objects
+[clock, street, shade, man, sneakers, headlight, car, bike, bike, sign, building, ... , street, sidewalk, trees, car, work truck]
+```
+
 ### License
 MIT License copyright Ranjay Krishna
 

--- a/src/local.py
+++ b/src/local.py
@@ -142,8 +142,7 @@ def ParseGraphLocal(data, image):
   attributes = []
   # Create the Objects
   for obj in data['objects']:
-    names.append(s['name'])
-    object_ = Object(obj['id'], obj['x'], obj['y'], obj['width'], obj['height'], names, [])
+    object_ = Object(obj['id'], obj['x'], obj['y'], obj['width'], obj['height'], obj['names'], [])
     object_map[obj['id']] = object_
     objects.append(object_)
   # Create the Relationships

--- a/src/local.py
+++ b/src/local.py
@@ -117,15 +117,14 @@ def SaveById(dataDir='data/', imageDataDir='data/by-id/'):
       ifname = imageDataDir + str(iid) + '.json'
 
       if os.path.exists(ifname):
-        fi = open(ifname, 'a')
-        data = json.load(fi)
+        with open(ifname, 'r') as f:
+          data = json.load(f)
       else:
-        fi = open(ifname, 'w')
         data = {'id' : iid}
 
       data[fname] = item[fname]
-      json.dump(data, fi)
-      fi.close()
+      with open(ifname, 'w') as f:
+        json.dump(data, f)
 
     del a
     gc.collect()

--- a/src/local.py
+++ b/src/local.py
@@ -264,7 +264,7 @@ def GetSceneGraphsModified(startIndex=0, endIndex=-1,
 
 
 import simplejson
-def GetSceneGraphsVRD(json_file='data/vrd/test.json', minRels=1, maxRels=100):
+def GetSceneGraphsVRD(json_file='data/vrd/json/test.json'):
   scene_graphs = []
   with open(json_file,'r') as f:
     D = simplejson.load(f)
@@ -274,7 +274,7 @@ def GetSceneGraphsVRD(json_file='data/vrd/test.json', minRels=1, maxRels=100):
 
 
 def ParseGraphVRD(d):
-  image = Image(data['photo_id'], data['filename'], data['width'], data['height'], '', '')
+  image = Image(d['photo_id'], d['filename'], d['width'], d['height'], '', '')
 
   id2obj = {}
   objs = []
@@ -287,10 +287,10 @@ def ParseGraphVRD(d):
     id2obj[i] = obj
     objs.append(obj)
 
-    for j,a in enumerate(data['attributes']):
+    for j,a in enumerate(d['attributes']):
       atrs.append(Attribute(j, obj, a['attribute'], []))
 
-  for i,r in enumerate(data['relationships']):
+  for i,r in enumerate(d['relationships']):
     s = id2obj[r['objects'][0]]
     o = id2obj[r['objects'][1]]
     v = r['relationship']

--- a/src/local.py
+++ b/src/local.py
@@ -132,7 +132,12 @@ def SaveById(dataDir='data/', imageDataDir='data/by-id/'):
 """
 Modified version of `utils.ParseGraph`.
 
-  Note: synset data for objects is not provided in the downloadable .json files
+Note
+----
+- synset data for objects is not provided in the downloadable .json files, so synset
+  is not included in the loaded Object, Relationship, and Attribute objects
+- attribute json data does not give full object, only `object names` string,
+  so Attribute objects do not link to Object objects
 
 """
 def ParseGraphLocal(data, image):
@@ -147,11 +152,14 @@ def ParseGraphLocal(data, image):
     objects.append(object_)
   # Create the Relationships
   for rel in data['relationships']:
-    relationships.append(Relationship(rel['id'], object_map[rel['subject']], \
-        rel['predicate'], object_map[rel['object']], []))
+    s = object_map[rel['subject'].id]
+    o = object_map[rel['object'].id]
+
+    relationships.append(Relationship(rel['id'], s, rel['predicate'], o, []))
   # Create the Attributes
   for atr in data['attributes']:
-    attributes.append(Attribute(atr['id'], object_map[atr['subject']], \
-        atr['attribute'], []))
+    s = atr['object_names'][0]
+    for a in atr['attributes']:
+      attributes.append(Attribute(atr['id'], s, a, []))
   return Graph(image, objects, relationships, attributes)
 

--- a/src/local.py
+++ b/src/local.py
@@ -50,3 +50,87 @@ def GetAllQAs(dataDir=None):
     output.append(utils.ParseQA(image['qas'], imageMap))
   return output
 
+
+"""
+Convert list of objects with `id` attribute to dictionary indexing objects by id.
+
+"""
+def ListToDict(ls):
+  return {obj.id:obj for obj in ls}
+
+
+"""
+Get all scene graphs.
+
+"""
+def GetAllSceneGraphs(dataDir='data/', imageDataDir='data/by-id/'):
+  images = ListToDict(GetAllImageData(dataDir))
+  scene_graphs = []
+
+  for fname in os.listdir(imageDataDir):
+    image_id = fname.split('.')[0]
+    image = images[image_id]
+    data = json.load(open(imageDataDir + fname, 'r'))
+
+    scene_graph = utils.ParseGraph(data, image)
+    scene_graphs.append(scene_graph)
+
+  return scene_graphs
+
+
+def GetSceneGraphs(image_id, images='data/', imageDataDir='data/by-id/'):
+  if type(images) is str:
+    images = ListToDict(GetAllImageData(images))
+
+  fname = str(image_id) + '.json'
+  image = images[str(image_id)]
+  data = json.load(open(imageDataDir + fname, 'r'))
+
+  scene_graph = utils.ParseGraph(data, image)
+  return scene_graph
+
+
+
+
+"""
+Save a unique json file for each image id; required for GetSceneGraphs.
+
+Each json has the following info:
+  - 'id'
+  - 'attributes'
+  - 'objects'
+  - 'relationships'
+
+"""
+def SaveById(dataDir='data/', imageDataDir='data/by-id/'):
+  import gc
+  if not os.path.exists(imageDataDir): os.mkdir(imageDataDir)
+
+  fnames = ['attributes','objects','relationships']
+  for fname in fnames:
+
+    with open(dataDir + fname + '.json', 'r') as f:
+      a = json.load(f)
+
+    for item in a:
+      iid = item['id']
+      ifname = imageDataDir + str(iid) + '.json'
+
+      if os.path.exists(ifname):
+        fi = open(ifname, 'a')
+        data = json.load(fi)
+      else:
+        fi = open(ifname, 'w')
+        data = {'id' : iid}
+
+      data[fname] = item[fname]
+      json.dump(data, fi)
+      fi.close()
+
+    del a
+    gc.collect()
+
+
+
+
+

--- a/src/local.py
+++ b/src/local.py
@@ -287,7 +287,7 @@ def ParseGraphVRD(d):
     id2obj[i] = obj
     objs.append(obj)
 
-    for j,a in enumerate(d['attributes']):
+    for j,a in enumerate(o['attributes']):
       atrs.append(Attribute(j, obj, a['attribute'], []))
 
   for i,r in enumerate(d['relationships']):

--- a/src/local.py
+++ b/src/local.py
@@ -50,3 +50,134 @@ def GetAllQAs(dataDir=None):
     output.append(utils.ParseQA(image['qas'], imageMap))
   return output
 
+
+"""
+Convert list of objects with `id` attribute to dictionary indexing objects by id.
+"""
+def ListToDict(ls):
+  return {obj.id:obj for obj in ls}
+
+"""
+Load a single scene graph from a .json file.
+"""
+def GetSceneGraph(image_id, images='data/', imageDataDir='data/by-id/'):
+  if type(images) is str:
+    images = ListToDict(GetAllImageData(images))
+
+  fname = str(image_id) + '.json'
+  image = images[image_id]
+  data = json.load(open(imageDataDir + fname, 'r'))
+
+  scene_graph = ParseGraphLocal(data, image)
+  return scene_graph
+
+"""
+Get scene graphs given locally stored .json files; requires `SaveSceneGraphsById`.
+
+startIndex, endIndex : get scene graphs listed by image, from startIndex through endIndex
+dataDir : directory with `image_data.json`
+imageDataDir : directory of scene graph jsons by image id; see `SaveSceneGraphsById`
+minRels, maxRels: only get scene graphs with at least / less than this number of relationships
+"""
+def GetSceneGraphs(startIndex=0, endIndex=-1,
+                   dataDir='data/', imageDataDir='data/by-id/',
+                   minRels=1, maxRels=100):
+  images = ListToDict(GetAllImageData(dataDir))
+  scene_graphs = []
+
+  img_fnames = os.listdir(imageDataDir)
+  if (endIndex < 1): endIndex = len(img_fnames)
+
+  for fname in img_fnames[startIndex : endIndex]:
+    image_id = int(fname.split('.')[0])
+    scene_graph = GetSceneGraph(image_id, images, imageDataDir)
+    n_rels = len(scene_graph.relationships)
+    if (minRels <= n_rels <= maxRels):
+      scene_graphs.append(scene_graph)
+
+  return scene_graphs
+
+"""
+Save a separate .json file for each image id in `imageDataDir`.
+
+Notes
+-----
+- Required for `GetSceneGraphs`, which loads all scene graph info for
+  a subset of all scene graphs.
+- `imageDataDir` will fill about 1.1G of space on disk
+- `dataDir` is assumed to contain `objects.json`, `attributes.json`,
+and `relationships.json`
+
+Each output .json has the following keys:
+  - "id"
+  - "attributes"
+  - "objects"
+  - "relationships"
+"""
+def SaveSceneGraphsById(dataDir='data/', imageDataDir='data/by-id/'):
+  import gc
+  if not os.path.exists(imageDataDir): os.mkdir(imageDataDir)
+
+  fnames = ['attributes','objects','relationships']
+  for fname in fnames:
+
+    with open(dataDir + fname + '.json', 'r') as f:
+      a = json.load(f)
+
+    for item in a:
+      iid = item['id']
+      ifname = imageDataDir + str(iid) + '.json'
+      if os.path.exists(ifname):
+        with open(ifname, 'r') as f:
+          data = json.load(f)
+      else:
+        data = {'id':iid}
+      data[fname] = item[fname]
+      with open(ifname, 'w') as f:
+        json.dump(data, f)
+
+    del a
+    gc.collect()  # clear memory
+
+
+def MapObject(object_map, obj):
+  oid = obj['id']
+  if oid in object_map:
+    object_ = object_map[obj['id']]
+  else:
+    names = obj['names'] if 'names' in obj else [obj['name']]
+    object_ = Object(obj['id'], obj['x'], obj['y'], obj['w'], obj['h'], names, [])
+    object_map[obj['id']] = object_
+  return object_map, object_
+
+
+"""
+Modified version of `utils.ParseGraph`.
+
+Note
+----
+- synset data for objects is not provided in the downloadable .json files, so synset
+  is not included in the loaded Object, Relationship, and Attribute objects
+- attribute json data does not give full object, only `object names` string,
+  so Attribute objects do not link to Object objects
+"""
+def ParseGraphLocal(data, image):
+  objects = []
+  object_map = {}
+  relationships = []
+  attributes = []
+
+  for obj in data['objects']:
+    object_map, o_ = MapObject(object_map, obj)
+    objects.append(o_)
+  for rel in data['relationships']:
+    object_map, s = MapObject(object_map, rel['subject'])
+    v = rel['predicate']
+    object_map, o = MapObject(object_map, rel['object'])
+    relationships.append(Relationship(rel['id'], s, v, o, []))
+
+  for atr in data['attributes']:
+    s = atr['object_names'][0]
+    for a in atr['attributes']:
+      attributes.append(Attribute(atr['id'], s, a, []))
+  return Graph(image, objects, relationships, attributes)

--- a/src/local.py
+++ b/src/local.py
@@ -72,7 +72,7 @@ def GetAllSceneGraphs(dataDir='data/', imageDataDir='data/by-id/'):
     image = images[image_id]
     data = json.load(open(imageDataDir + fname, 'r'))
 
-    scene_graph = utils.ParseGraph(data, image)
+    scene_graph = ParseGraphLocal(data, image)
     scene_graphs.append(scene_graph)
 
   return scene_graphs
@@ -83,10 +83,10 @@ def GetSceneGraphs(image_id, images='data/', imageDataDir='data/by-id/'):
     images = ListToDict(GetAllImageData(images))
 
   fname = str(image_id) + '.json'
-  image = images[str(image_id)]
+  image = images[image_id]
   data = json.load(open(imageDataDir + fname, 'r'))
 
-  scene_graph = utils.ParseGraph(data, image)
+  scene_graph = ParseGraphLocal(data, image)
   return scene_graph
 
 
@@ -95,7 +95,7 @@ def GetSceneGraphs(image_id, images='data/', imageDataDir='data/by-id/'):
 """
 Save a unique json file for each image id; required for GetSceneGraphs.
 
-Each json has the following info:
+Each json has the following keys:
   - 'id'
   - 'attributes'
   - 'objects'
@@ -129,7 +129,30 @@ def SaveById(dataDir='data/', imageDataDir='data/by-id/'):
     del a
     gc.collect()
 
+"""
+Modified version of `utils.ParseGraph`.
 
+  Note: synset data for objects is not provided in the downloadable .json files
 
-
+"""
+def ParseGraphLocal(data, image):
+  objects = []
+  object_map = {}
+  relationships = []
+  attributes = []
+  # Create the Objects
+  for obj in data['objects']:
+    names.append(s['name'])
+    object_ = Object(obj['id'], obj['x'], obj['y'], obj['width'], obj['height'], names, [])
+    object_map[obj['id']] = object_
+    objects.append(object_)
+  # Create the Relationships
+  for rel in data['relationships']:
+    relationships.append(Relationship(rel['id'], object_map[rel['subject']], \
+        rel['predicate'], object_map[rel['object']], []))
+  # Create the Attributes
+  for atr in data['attributes']:
+    attributes.append(Attribute(atr['id'], object_map[atr['subject']], \
+        atr['attribute'], []))
+  return Graph(image, objects, relationships, attributes)
 

--- a/src/local.py
+++ b/src/local.py
@@ -296,4 +296,4 @@ def ParseGraphVRD(d):
     v = r['relationship']
     rels.append(Relationship(i, s, v, o, []))
 
-  return Graph(image, objs, relationships, atrs)
+  return Graph(image, objs, rels, atrs)

--- a/src/local.py
+++ b/src/local.py
@@ -100,11 +100,13 @@ def GetSceneGraphs(startIndex=0, endIndex=-1,
 """
 Save a separate .json file for each image id in `imageDataDir`.
 
-Required for `GetSceneGraphs`, which loads all scene graph info for 
-a subset of all scene graphs.
-
-`dataDir` is assumed to contain `objects.json`, `attributes.json`, 
-and `relationships.json`.
+Notes
+-----
+- Required for `GetSceneGraphs`, which loads all scene graph info for 
+  a subset of all scene graphs.
+- `imageDataDir` will fill about 1.1G of space on disk
+- `dataDir` is assumed to contain `objects.json`, `attributes.json`, 
+and `relationships.json`
 
 Each output .json has the following keys:
   - "id"

--- a/src/local.py
+++ b/src/local.py
@@ -142,7 +142,7 @@ def ParseGraphLocal(data, image):
   attributes = []
   # Create the Objects
   for obj in data['objects']:
-    object_ = Object(obj['id'], obj['x'], obj['y'], obj['width'], obj['height'], obj['names'], [])
+    object_ = Object(obj['id'], obj['x'], obj['y'], obj['w'], obj['h'], obj['names'], [])
     object_map[obj['id']] = object_
     objects.append(object_)
   # Create the Relationships

--- a/src/utils.py
+++ b/src/utils.py
@@ -62,13 +62,14 @@ def ParseGraph(data, image):
 Helper to parse the image data for one image.
 """
 def ParseImageData(data):
+  img_id = data['id'] if 'id' in data else data['image_id']
   url = data['url']
   width = data['width']
   height = data['height']
   coco_id = data['coco_id']
   flickr_id = data['flickr_id']
-  image = Image(data['id'], url, width, height, coco_id, flickr_id)
-  return image	
+  image = Image(img_id, url, width, height, coco_id, flickr_id)
+  return image
 
 """
 Helper to parse region descriptions.
@@ -96,4 +97,4 @@ def ParseQA(data, image_map):
         synset = Synset(o['synset_name'], ao['synset_definition'])
         aos.append(QAObject(ao['entity_idx_start'], ao['entity_idx_end'], ao['entity_name'], synset))
     qas.append(QA(d['id'], image_map[d['image']], d['question'], d['answer'], qos, aos))
-  return qas 
+  return qas


### PR DESCRIPTION
This was a noteworthy absence in the project code given that many researchers will probably want to access the VG scene graphs data via the downloadable .json files. 

See docstrings of new functions in `local.py` for information. I tried to conform to stylistic conventions of the repo, although added functions don't use `utils.GetDataDir()`.
