### PR TITLE
fixed a bug in ParseGraphLocal

### DIFF
--- a/src/local.py
+++ b/src/local.py
@@ -14,7 +14,6 @@ def GetAllImageData(dataDir=None):
   dataFile = os.path.join(dataDir, 'image_data.json')
   data = json.load(open(dataFile))
   return [utils.ParseImageData(image) for image in data]
-
 """
 Get all region descriptions.
 """
@@ -158,7 +157,10 @@ def ParseGraphLocal(data, image, verbose=False):
     for attr in data['attributes']:
       a = attr['attribute']
       if a['object_id'] in object_map:
-        attributes.append(Attribute(attr['attribute_id'], a['object_id'], a['names'], a['synsets']))
+        # attributes.append(Attribute(attr['attribute_id'], a['object_id'], a['names'], a['synsets']))
+        # the second argument should be an Object 
+        attributes.append(Attribute(attr['attribute_id'], 
+          Object(a['object_id'], a['x'], a['y'], a['w'], a['h'], a['names'], a['synsets']), a['attributes'], a['synsets']))
       else:
         count_skips[1] += 1
   if verbose:

--- a/src/local.py
+++ b/src/local.py
@@ -157,7 +157,6 @@ def ParseGraphLocal(data, image, verbose=False):
     for attr in data['attributes']:
       a = attr['attribute']
       if a['object_id'] in object_map:
-        # attributes.append(Attribute(attr['attribute_id'], a['object_id'], a['names'], a['synsets']))
         # the second argument should be an Object 
         attributes.append(Attribute(attr['attribute_id'], 
           Object(a['object_id'], a['x'], a['y'], a['w'], a['h'], a['names'], a['synsets']), a['attributes'], a['synsets']))


### PR DESCRIPTION
Based on models.py, in order to create an Attribute, the second argument should be an Object and the third argument should be a string of the attribute. But in the original code, the second argument was not an Object and the third argument is the name of the object. 