### PR TITLE
Enforce integer division in get_image_ids_in_range

### DIFF
--- a/visual_genome/api.py
+++ b/visual_genome/api.py
@@ -24,8 +24,8 @@ def get_image_ids_in_range(start_index=0, end_index=99):
     Get Image ids from start_index to end_index.
     """
     ids_per_page = 1000
-    start_page = start_index / ids_per_page + 1
-    endPage = end_index / ids_per_page + 1
+    start_page = start_index // ids_per_page + 1
+    endPage = end_index // ids_per_page + 1
     ids = []
     for page in range(start_page, endPage + 1):
         data = utils.retrieve_data('/api/v0/images/all?page=' + str(page))

--- a/visual_genome/api.py
+++ b/visual_genome/api.py
@@ -25,9 +25,9 @@ def get_image_ids_in_range(start_index=0, end_index=99):
     """
     ids_per_page = 1000
     start_page = start_index // ids_per_page + 1
-    endPage = end_index // ids_per_page + 1
+    end_page = end_index // ids_per_page + 1
     ids = []
-    for page in range(start_page, endPage + 1):
+    for page in range(start_page, end_page + 1):
         data = utils.retrieve_data('/api/v0/images/all?page=' + str(page))
         ids.extend(data['results'])
     ids = ids[start_index % 100:]


### PR DESCRIPTION
Since in Python 3.6 dividing two integers with `/` produces a float, thus causing errors further in the method, I suggest explicitly using integer division `//`.
The change should be compatible with Python 2.

This pull request also renames `endPage` to snake case, for consistency with other variables.